### PR TITLE
Fix makefile (cli) and empty spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ module-image: docker-build docker-push ## Build the Module Image and push it to 
 
 .PHONY: module-build
 module-build: kyma ## Build the Module and push it to a registry defined in MODULE_REGISTRY
-	@$(KYMA) alpha create module kyma.project.io/module/$(MODULE_NAME) $(MODULE_VERSION) ./ $(MODULE_CREATION_FLAGS)
+	@$(KYMA) alpha create module --name=kyma.project.io/module/$(MODULE_NAME) --version=$(MODULE_VERSION) . $(MODULE_CREATION_FLAGS)
 
 .PHONY: module-template-push
 module-template-push: crane ## Pushes the ModuleTemplate referencing the Image on MODULE_REGISTRY

--- a/config/samples/operator_v1alpha1_serverless_k3d.yaml
+++ b/config/samples/operator_v1alpha1_serverless_k3d.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kuberentes.io/managed-by: kustomize
     app.kubernetes.io/created-by: serverless-manager
   name: serverless-sample
-spec:
+spec: {}
   # you don't need these field because they will be defaulted
   # dockerRegistry:
   #  enableInternal: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix empty spec for the sample function CR
```bash
\ Validating Default CRError: Error applying the default CR: Serverless.operator.kyma-project.io "serverless-sample" is invalid: spec: Invalid value: "null": spec in body must be of type object: "null"
make: *** [module-build] Error 1
```
- Fix `module-build` target as alpha comand API changed

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15858