### PR TITLE
Target installation namespace driven by reconciled Serverless CR

### DIFF
--- a/internal/state/fsm.go
+++ b/internal/state/fsm.go
@@ -3,11 +3,12 @@ package state
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
 	"reflect"
 	"runtime"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/kyma-project/module-manager/pkg/types"
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
@@ -24,10 +25,8 @@ var (
 type stateFn func(context.Context, *reconciler, *systemState) (stateFn, *ctrl.Result, error)
 
 type cfg struct {
-	finalizer       string
-	chartPath       string
-	chartNs         string
-	createNamespace bool
+	finalizer string
+	chartPath string
 }
 
 type systemState struct {
@@ -39,7 +38,7 @@ func (s *systemState) setState(state v1alpha1.State) {
 	s.instance.Status.State = state
 }
 
-func (s *systemState) Setup(ctx context.Context, c client.Client, chartNS string) error {
+func (s *systemState) Setup(ctx context.Context, c client.Client) error {
 	s.instance.Spec.Default()
 
 	s.dockerRegistry = map[string]interface{}{
@@ -49,7 +48,7 @@ func (s *systemState) Setup(ctx context.Context, c client.Client, chartNS string
 	if s.instance.Spec.DockerRegistry.SecretName != nil {
 		var secret corev1.Secret
 		key := client.ObjectKey{
-			Namespace: chartNS,
+			Namespace: s.instance.Namespace,
 			Name:      *s.instance.Spec.DockerRegistry.SecretName,
 		}
 		err := c.Get(ctx, key, &secret)

--- a/internal/state/new.go
+++ b/internal/state/new.go
@@ -11,11 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	chartNs         = "kyma-system"
-	createNamespace = false // TODO: think about it
-)
-
 type StateReconciler interface {
 	Reconcile(ctx context.Context, v v1alpha1.Serverless) (ctrl.Result, error)
 }
@@ -26,10 +21,8 @@ func NewMachine(client client.Client, config *rest.Config, log *zap.SugaredLogge
 		cacheManager: cache,
 		log:          log,
 		cfg: cfg{
-			finalizer:       v1alpha1.Finalizer,
-			chartPath:       chartPath,
-			chartNs:         chartNs,
-			createNamespace: createNamespace,
+			finalizer: v1alpha1.Finalizer,
+			chartPath: chartPath,
 		},
 		k8s: k8s{
 			client: client,

--- a/internal/state/state_functions.go
+++ b/internal/state/state_functions.go
@@ -45,7 +45,7 @@ func sFnInitialize(ctx context.Context, r *reconciler, s *systemState) (stateFn,
 		return sFnUpdateServerlessStatus(v1alpha1.StateProcessing)
 	}
 
-	err := s.Setup(ctx, r.client, r.cfg.chartNs)
+	err := s.Setup(ctx, r.client)
 	if err != nil {
 		return sFnUpdateServerlessStatus(v1alpha1.StateError)
 	}
@@ -231,8 +231,7 @@ func installationSpec(r *reconciler, s *systemState) (*types.InstallationSpec, e
 		ChartPath: r.chartPath,
 		ChartFlags: types.ChartFlags{
 			ConfigFlags: types.Flags{
-				"Namespace":       r.chartNs,
-				"CreateNamespace": r.createNamespace,
+				"Namespace": s.instance.Namespace,
 			},
 			SetFlags: flags,
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- serverless is installed in the namespace where Serverless CR is created

**Related issue(s)**
#65 