### PR TITLE
Add render-manifest make target

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 0.0.1
+    MODULE_VERSION = 0.0.2
 endif

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ template-k3d.yaml
 docs/.DS_Store
 .DS_Store
 vendor
+
+serverless-manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: render-manifest
+render-manifest: manifests kustomize ## Render keda-manager.yaml manifest.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > serverless-manager.yaml
+
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with IGNORE_NOT_FOUND=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f -

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -63,3 +63,7 @@ run-with-lifecycle-manager:
 .PHONY: run-without-lifecycle-manager
 run-without-lifecycle-manager:
 	@make -C ${PROJECT_COMMON} run-without-lifecycle-manager
+
+.PHONY: render-manifest
+render-manifest:
+	@make -C ${PROJECT_ROOT} render-manifest


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add make target useful to render serverless-manager manifests
- bump module version to 0.0.2

**Related issue(s)**
https://github.com/kyma-project/keda-manager/pull/127