### PR TITLE
Build installation flags manually

### DIFF
--- a/internal/chart/flags.go
+++ b/internal/chart/flags.go
@@ -1,0 +1,50 @@
+package chart
+
+import (
+	"context"
+
+	"github.com/kyma-project/serverless-manager/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type flags map[string]interface{}
+
+// build flags for the installation. The Serverless resource should be validated and ready to use
+func BuildFlags(ctx context.Context, client client.Client, serverless *v1alpha1.Serverless) (map[string]interface{}, error) {
+	dockerRegistryFlags, err := dockerRegistryFlags(ctx, client, serverless)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"dockerRegistry": dockerRegistryFlags,
+	}, nil
+}
+
+func dockerRegistryFlags(ctx context.Context, c client.Client, serverless *v1alpha1.Serverless) (map[string]interface{}, error) {
+	flags := map[string]interface{}{
+		"enableInternal":  *serverless.Spec.DockerRegistry.EnableInternal,
+		"registryAddress": v1alpha1.DefaultRegistryAddress,
+		"serverAddress":   v1alpha1.DefaultServerAddress,
+	}
+
+	if serverless.Spec.DockerRegistry.SecretName != nil {
+		var secret corev1.Secret
+		key := client.ObjectKey{
+			Namespace: serverless.Namespace,
+			Name:      *serverless.Spec.DockerRegistry.SecretName,
+		}
+		err := c.Get(ctx, key, &secret)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range []string{"username", "password", "registryAddress", "serverAddress"} {
+			if v, ok := secret.Data[k]; ok {
+				flags[k] = string(v)
+			}
+		}
+	}
+
+	return flags, nil
+}

--- a/internal/chart/flags_test.go
+++ b/internal/chart/flags_test.go
@@ -1,0 +1,126 @@
+package chart
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/kyma-project/serverless-manager/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testRegistrySecret = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"username":        []byte("test-username"),
+			"password":        []byte("test-password"),
+			"registryAddress": []byte("test-registryAddress"),
+			"serverAddress":   []byte("test-serverAddress"),
+		},
+	}
+)
+
+func TestBuildFlags(t *testing.T) {
+	type args struct {
+		ctx        context.Context
+		client     client.Client
+		serverless *v1alpha1.Serverless
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "build from resource",
+			args: args{
+				serverless: &v1alpha1.Serverless{
+					Spec: v1alpha1.ServerlessSpec{
+						DockerRegistry: &v1alpha1.DockerRegistry{
+							EnableInternal: pointer.Bool(true),
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"dockerRegistry": func() map[string]interface{} {
+					return map[string]interface{}{
+						"enableInternal":  true,
+						"registryAddress": "k3d-kyma-registry:5000",
+						"serverAddress":   "k3d-kyma-registry:5000",
+					}
+				}(),
+			},
+		},
+		{
+			name: "with secretName",
+			args: args{
+				ctx:    context.Background(),
+				client: fake.NewFakeClient(&testRegistrySecret),
+				serverless: &v1alpha1.Serverless{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testRegistrySecret.Namespace,
+					},
+					Spec: v1alpha1.ServerlessSpec{
+						DockerRegistry: &v1alpha1.DockerRegistry{
+							EnableInternal: pointer.Bool(true),
+							SecretName:     pointer.String(testRegistrySecret.Name),
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"dockerRegistry": func() map[string]interface{} {
+					return map[string]interface{}{
+						"enableInternal":  true,
+						"username":        "test-username",
+						"password":        "test-password",
+						"registryAddress": "test-registryAddress",
+						"serverAddress":   "test-serverAddress",
+					}
+				}(),
+			},
+		},
+		{
+			name: "secret not found",
+			args: args{
+				ctx:    context.Background(),
+				client: fake.NewFakeClient(),
+				serverless: &v1alpha1.Serverless{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testRegistrySecret.Namespace,
+					},
+					Spec: v1alpha1.ServerlessSpec{
+						DockerRegistry: &v1alpha1.DockerRegistry{
+							EnableInternal: pointer.Bool(true),
+							SecretName:     pointer.String(testRegistrySecret.Name),
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildFlags(tt.args.ctx, tt.args.client, tt.args.serverless)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- we have some cases where autogeneration of flags based on the spec CR is a huge challenge (`secretName`, `eventPublisherProxyUrl`, `traceCollectorUrl`). Because of that, I decided to get rid of the auto-generated flags and create a function to build them manually. Also, it will open the way to easily get rid of the helm, because our actual Spec structure does not need to be a reflection of the values.yaml file.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/15