### PR TITLE
Change order of parsed resources

### DIFF
--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -63,7 +63,10 @@ func parseManifest(manifest string) ([]unstructured.Unstructured, error) {
 		}
 
 		u := unstructured.Unstructured{Object: obj}
-		if u.GetObjectKind().GroupVersionKind().Kind == "CustomResourceDefinition" {
+		// some resources need to be applied first (before workloads)
+		// if this statement gets bigger then extract it to the separated place
+		if u.GetObjectKind().GroupVersionKind().Kind == "CustomResourceDefinition" ||
+			u.GetObjectKind().GroupVersionKind().Kind == "PriorityClass" {
 			results = append([]unstructured.Unstructured{u}, results...)
 			continue
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- wrong applied resources order cause warning events - to fix It, I've changed the order of resources to apply

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/96