### PR TITLE
Cover case when Serverless CR is duplicated

### DIFF
--- a/api/v1alpha1/serverless_types.go
+++ b/api/v1alpha1/serverless_types.go
@@ -38,6 +38,8 @@ type ServerlessSpec struct {
 
 type State string
 
+type Served string
+
 type ConditionReason string
 
 type ConditionType string
@@ -48,18 +50,22 @@ const (
 	StateError      State = "Error"
 	StateDeleting   State = "Deleting"
 
+	ServedTrue  Served = "True"
+	ServedFalse Served = "False"
+
 	// installation and deletion details
 	ConditionTypeInstalled = ConditionType("Installed")
 
 	// prerequisites and soft dependencies
 	ConditionTypeConfigured = ConditionType("Configured")
 
-	ConditionReasonConfigurationCheck = ConditionReason("ConfigurationCheck")
-	ConditionReasonConfigurationErr   = ConditionReason("ConfigurationCheckErr")
-	ConditionReasonConfigured         = ConditionReason("Configured")
-	ConditionReasonInstallation       = ConditionReason("Installation")
-	ConditionReasonInstallationErr    = ConditionReason("InstallationErr")
-	ConditionReasonInstalled          = ConditionReason("Installed")
+	ConditionReasonConfigurationCheck   = ConditionReason("ConfigurationCheck")
+	ConditionReasonConfigurationErr     = ConditionReason("ConfigurationCheckErr")
+	ConditionReasonConfigured           = ConditionReason("Configured")
+	ConditionReasonInstallation         = ConditionReason("Installation")
+	ConditionReasonInstallationErr      = ConditionReason("InstallationErr")
+	ConditionReasonInstalled            = ConditionReason("Installed")
+	ConditionReasonServerlessDuplicated = ConditionReason("ServerlessDuplicated")
 
 	Finalizer = "serverless-manager.kyma-project.io/deletion-hook"
 )
@@ -73,7 +79,12 @@ type ServerlessStatus struct {
 	// Value can be one of ("Ready", "Processing", "Error", "Deleting").
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=Processing;Deleting;Ready;Error
-	State State `json:"state"`
+	State State `json:"state,omitempty"`
+
+	// Served signifies that current Serverless is managed.
+	// Value can be one of ("True", "False").
+	// +kubebuilder:validation:Enum=True;False
+	Served Served `json:"served"`
 
 	// Conditions associated with CustomStatus.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -129,6 +140,10 @@ func (s *Serverless) UpdateConditionTrue(c ConditionType, r ConditionReason, msg
 		Message:            msg,
 	}
 	meta.SetStatusCondition(&s.Status.Conditions, condition)
+}
+
+func (s *Serverless) IsServedEmpty() bool {
+	return s.Status.Served == ""
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/operator.kyma-project.io_serverlesses.yaml
+++ b/config/crd/bases/operator.kyma-project.io_serverlesses.yaml
@@ -143,6 +143,13 @@ spec:
               eventPublisherProxyURL:
                 description: Used the Publisher Proxy and the Trace Collector URLs.
                 type: string
+              served:
+                description: Served signifies that current Serverless is managed.
+                  Value can be one of ("True", "False").
+                enum:
+                - "True"
+                - "False"
+                type: string
               state:
                 description: State signifies current state of Serverless. Value can
                   be one of ("Ready", "Processing", "Error", "Deleting").
@@ -155,7 +162,7 @@ spec:
               traceCollectorURL:
                 type: string
             required:
-            - state
+            - served
             type: object
         type: object
     served: true

--- a/internal/chart/install.go
+++ b/internal/chart/install.go
@@ -25,7 +25,7 @@ func Install(config *Config) error {
 		config.Log.Debugf("creating %s %s/%s", u.GetKind(), u.GetNamespace(), u.GetName())
 		err := config.Cluster.Client.Patch(config.Ctx, &u, client.Apply, &client.PatchOptions{
 			Force:        pointer.Bool(true),
-			FieldManager: "keda-manager",
+			FieldManager: "serverless-manager",
 		})
 		if err != nil {
 			return fmt.Errorf("could not install object %s/%s: %s", u.GetNamespace(), u.GetName(), err.Error())

--- a/internal/state/fsm.go
+++ b/internal/state/fsm.go
@@ -45,6 +45,10 @@ func (s *systemState) setState(state v1alpha1.State) {
 	s.instance.Status.State = state
 }
 
+func (s *systemState) setServed(served v1alpha1.Served) {
+	s.instance.Status.Served = served
+}
+
 func (s *systemState) Setup(ctx context.Context, r *reconciler) error {
 	s.instance.Spec.Default()
 

--- a/internal/state/new.go
+++ b/internal/state/new.go
@@ -18,7 +18,7 @@ type StateReconciler interface {
 
 func NewMachine(client client.Client, config *rest.Config, recorder record.EventRecorder, log *zap.SugaredLogger, cache *chart.ManifestCache, chartPath string) StateReconciler {
 	return &reconciler{
-		fn:    sFnTakePreInitSnapshot,
+		fn:    sFnServedFilter,
 		cache: cache,
 		log:   log,
 		cfg: cfg{

--- a/internal/state/served_filter.go
+++ b/internal/state/served_filter.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/serverless-manager/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func sFnServedFilter(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
+	if s.instance.IsServedEmpty() {
+		servedServerless, err := findServedServerless(ctx, r.k8s.client)
+		if err != nil {
+			return stopWithError(err)
+		}
+
+		if servedServerless == nil {
+			return nextState(sFnUpdateServedTrue())
+		}
+		return nextState(
+			sFnUpdateServedFalse(
+				v1alpha1.ConditionTypeConfigured,
+				v1alpha1.ConditionReasonServerlessDuplicated,
+				fmt.Errorf("only one instance of Serverless is allowed (current served instance: %s/%s)",
+					servedServerless.GetNamespace(), servedServerless.GetName())))
+	}
+
+	if s.instance.Status.Served == v1alpha1.ServedFalse {
+		return nil, nil, nil
+	}
+
+	return nextState(sFnTakePreInitSnapshot)
+}
+
+func findServedServerless(ctx context.Context, c client.Client) (*v1alpha1.Serverless, error) {
+	var serverlessList v1alpha1.ServerlessList
+
+	err := c.List(ctx, &serverlessList)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range serverlessList.Items {
+		if !item.IsServedEmpty() && item.Status.Served == v1alpha1.ServedTrue {
+			return &item, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/state/served_filter_test.go
+++ b/internal/state/served_filter_test.go
@@ -1,0 +1,133 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"github.com/kyma-project/serverless-manager/api/v1alpha1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_sFnServedFilter(t *testing.T) {
+	t.Run("skip processing when served is false", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Status: v1alpha1.ServerlessStatus{
+					Served: v1alpha1.ServedFalse,
+				},
+			},
+		}
+
+		nextFn, result, err := sFnServedFilter(context.TODO(), nil, s)
+
+		require.Nil(t, err)
+		require.Nil(t, nextFn)
+		require.Nil(t, result)
+	})
+
+	t.Run("do next step when served is true", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Status: v1alpha1.ServerlessStatus{
+					Served: v1alpha1.ServedTrue,
+				},
+			},
+		}
+
+		nextFn, result, err := sFnServedFilter(context.TODO(), nil, s)
+
+		require.Nil(t, err)
+		requireEqualFunc(t, sFnTakePreInitSnapshot, nextFn)
+		require.Nil(t, result)
+	})
+
+	t.Run("set served value from nil to true when there is no served serverless on cluster", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Status: v1alpha1.ServerlessStatus{},
+			},
+		}
+
+		r := &reconciler{
+			k8s: k8s{
+				client: func() client.Client {
+					scheme := apiruntime.NewScheme()
+					require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+					client := fake.NewClientBuilder().
+						WithScheme(scheme).
+						WithObjects(
+							fixServedServerless("test-1", "default", ""),
+							fixServedServerless("test-2", "serverless-test", v1alpha1.ServedFalse),
+							fixServedServerless("test-3", "serverless-test-2", ""),
+							fixServedServerless("test-4", "default", v1alpha1.ServedFalse),
+						).Build()
+
+					return client
+				}(),
+			},
+		}
+
+		nextFn, result, err := sFnServedFilter(context.TODO(), r, s)
+
+		require.Nil(t, err)
+		requireEqualFunc(t, sFnUpdateServedTrue(), nextFn)
+		require.Nil(t, result)
+	})
+
+	t.Run("set served value from nil to false and set condition to error when there is at lease one served serverless on cluster", func(t *testing.T) {
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				Status: v1alpha1.ServerlessStatus{},
+			},
+		}
+
+		r := &reconciler{
+			k8s: k8s{
+				client: func() client.Client {
+					scheme := apiruntime.NewScheme()
+					require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+					client := fake.NewClientBuilder().
+						WithScheme(scheme).
+						WithObjects(
+							fixServedServerless("test-1", "default", v1alpha1.ServedFalse),
+							fixServedServerless("test-2", "serverless-test", v1alpha1.ServedTrue),
+							fixServedServerless("test-3", "serverless-test-2", ""),
+							fixServedServerless("test-4", "default", v1alpha1.ServedFalse),
+						).Build()
+
+					return client
+				}(),
+			},
+		}
+
+		nextFn, result, err := sFnServedFilter(context.TODO(), r, s)
+
+		require.Nil(t, err)
+		requireEqualFunc(t,
+			sFnUpdateServedFalse(
+				v1alpha1.ConditionTypeConfigured,
+				v1alpha1.ConditionReasonServerlessDuplicated,
+				errors.New("only one instance of Serverless is allowed (current served instance: serverless-test/test-2)")),
+			nextFn)
+		require.Nil(t, result)
+	})
+}
+
+func fixServedServerless(name, namespace string, served v1alpha1.Served) *v1alpha1.Serverless {
+	return &v1alpha1.Serverless{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v1alpha1.ServerlessStatus{
+			Served: served,
+		},
+	}
+}

--- a/internal/state/update_status.go
+++ b/internal/state/update_status.go
@@ -80,12 +80,17 @@ func sFnUpdateServerless() stateFn {
 	}
 }
 
-func sFnUpdateServerlessStatus(next stateFn) stateFn {
+func sFnUpdateServedTrue() stateFn {
 	return func(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
-		return updateServerlessStatus(
-			sFnTakeSnapshot(next, nil, nil),
-			ctx, r, s,
-		)
+		s.setServed(v1alpha1.ServedTrue)
+		return updateServerlessStatus(sFnRequeue(), ctx, r, s)
+	}
+}
+
+func sFnUpdateServedFalse(condition v1alpha1.ConditionType, reason v1alpha1.ConditionReason, err error) stateFn {
+	return func(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
+		s.setServed(v1alpha1.ServedFalse)
+		return nextState(sFnUpdateErrorState(condition, reason, err))
 	}
 }
 

--- a/internal/state/update_status_test.go
+++ b/internal/state/update_status_test.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"github.com/kyma-project/serverless-manager/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func Test_sFnUpdateServedTrue(t *testing.T) {
+	t.Run("set served to true", func(t *testing.T) {
+		serverless := v1alpha1.Serverless{
+			ObjectMeta: v1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "serverless-test",
+				ResourceVersion: "222",
+			},
+			Status: v1alpha1.ServerlessStatus{},
+		}
+		s := &systemState{
+			instance: serverless,
+		}
+
+		r := &reconciler{
+			k8s: k8s{
+				client: func() client.Client {
+					scheme := apiruntime.NewScheme()
+					require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+					client := fake.NewClientBuilder().
+						WithScheme(scheme).
+						WithObjects(serverless.DeepCopy()).
+						Build()
+
+					return client
+				}(),
+			},
+		}
+
+		nextFn, result, err := sFnUpdateServedTrue()(context.TODO(), r, s)
+
+		require.Nil(t, err)
+		//requireEqualFunc(t, sFnRequeue(), nextFn) //TODO: these names aren't equal - why?
+		require.NotNil(t, nextFn)
+		require.Nil(t, result)
+
+		require.Equal(t, v1alpha1.ServedTrue, s.instance.Status.Served)
+	})
+}
+
+func Test_sFnUpdateServedFalse(t *testing.T) {
+	t.Run("set served to false", func(t *testing.T) {
+		serverless := v1alpha1.Serverless{
+			ObjectMeta: v1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "serverless-test",
+				ResourceVersion: "222",
+			},
+			Status: v1alpha1.ServerlessStatus{},
+		}
+		s := &systemState{
+			instance: serverless,
+		}
+
+		r := &reconciler{
+			k8s: k8s{
+				client: func() client.Client {
+					scheme := apiruntime.NewScheme()
+					require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+					client := fake.NewClientBuilder().
+						WithScheme(scheme).
+						WithObjects(serverless.DeepCopy()).
+						Build()
+
+					return client
+				}(),
+			},
+		}
+
+		nextFn, result, err := sFnUpdateServedFalse(v1alpha1.ConditionTypeConfigured, v1alpha1.ConditionReasonServerlessDuplicated, errors.New("some error text"))(context.TODO(), r, s)
+
+		require.Nil(t, err)
+		//requireEqualFunc(t, sFnRequeue(), nextFn) //TODO: these names aren't equal - why?
+		require.NotNil(t, nextFn)
+		require.Nil(t, result)
+
+		require.Equal(t, v1alpha1.ServedFalse, s.instance.Status.Served)
+		//TODO: in this state we can't check condition state
+	})
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add new `served` field to the status
- add new state to label served Serverless CR and filter out other Serverless CRs
- add tests for new state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #103 