### PR TITLE
Reimplement cache strategy

### DIFF
--- a/internal/chart/cache_test.go
+++ b/internal/chart/cache_test.go
@@ -90,7 +90,7 @@ func TestManifestCache_Get(t *testing.T) {
 		result, err := cache.Get(ctx, key)
 		require.NoError(t, err)
 
-		expectedResult := &ServerlessSpecManifest{
+		expectedResult := ServerlessSpecManifest{
 			customFlags: map[string]interface{}{
 				"flag1": "val1",
 				"flag2": "val2",
@@ -116,7 +116,7 @@ func TestManifestCache_Get(t *testing.T) {
 
 		result, err := cache.Get(ctx, key)
 		require.Error(t, err)
-		require.Nil(t, result)
+		require.Equal(t, emptyServerlessSpecManifest, result)
 	})
 
 	t.Run("secret not found", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestManifestCache_Get(t *testing.T) {
 
 		result, err := cache.Get(ctx, key)
 		require.NoError(t, err)
-		require.Nil(t, result)
+		require.Equal(t, emptyServerlessSpecManifest, result)
 	})
 
 	t.Run("conversion error", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestManifestCache_Get(t *testing.T) {
 
 		result, err := cache.Get(ctx, key)
 		require.Error(t, err)
-		require.Nil(t, result)
+		require.Equal(t, emptyServerlessSpecManifest, result)
 	})
 }
 

--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -77,13 +77,13 @@ func parseManifest(manifest string) ([]unstructured.Unstructured, error) {
 	return results, nil
 }
 
-func getManifest(config *Config) (string, error) {
+func getOrRenderManifest(config *Config) (string, error) {
 	specManifest, err := config.Cache.Get(config.Ctx, config.CacheKey)
 	if err != nil {
 		return "", err
 	}
 
-	if specManifest != nil && reflect.DeepEqual(specManifest.customFlags, config.Release.Flags) {
+	if reflect.DeepEqual(specManifest.customFlags, config.Release.Flags) {
 		return specManifest.manifest, nil
 	}
 
@@ -92,7 +92,7 @@ func getManifest(config *Config) (string, error) {
 		return "", err
 	}
 
-	return release.Manifest, config.Cache.Set(config.Ctx, config.CacheKey, config.Release.Flags, release.Manifest)
+	return release.Manifest, nil
 }
 
 func renderChart(config *Config) (*release.Release, error) {

--- a/internal/chart/check.go
+++ b/internal/chart/check.go
@@ -13,12 +13,12 @@ import (
 )
 
 func CheckCRDOrphanResources(config *Config) error {
-	manifest, err := getManifest(config)
+	spec, err := config.Cache.Get(config.Ctx, config.CacheKey)
 	if err != nil {
 		return fmt.Errorf("could not render manifest from chart: %s", err.Error())
 	}
 
-	objs, err := parseManifest(manifest)
+	objs, err := parseManifest(spec.manifest)
 	if err != nil {
 		return fmt.Errorf("could not parse chart manifest: %s", err.Error())
 	}

--- a/internal/chart/uninstall.go
+++ b/internal/chart/uninstall.go
@@ -10,12 +10,12 @@ import (
 type FilterFunc func(unstructured.Unstructured) bool
 
 func Uninstall(config *Config, filterFunc ...FilterFunc) error {
-	manifest, err := getManifest(config)
+	spec, err := config.Cache.Get(config.Ctx, config.CacheKey)
 	if err != nil {
 		return fmt.Errorf("could not render manifest from chart: %s", err.Error())
 	}
 
-	objs, err := parseManifest(manifest)
+	objs, err := parseManifest(spec.manifest)
 	if err != nil {
 		return fmt.Errorf("could not parse chart manifest: %s", err.Error())
 	}

--- a/internal/chart/verify.go
+++ b/internal/chart/verify.go
@@ -10,12 +10,12 @@ import (
 )
 
 func Verify(config *Config) (bool, error) {
-	manifest, err := getManifest(config)
+	spec, err := config.Cache.Get(config.Ctx, config.CacheKey)
 	if err != nil {
 		return false, fmt.Errorf("could not render manifest from chart: %s", err.Error())
 	}
 
-	objs, err := parseManifest(manifest)
+	objs, err := parseManifest(spec.manifest)
 	if err != nil {
 		return false, fmt.Errorf("could not parse chart manifest: %s", err.Error())
 	}

--- a/internal/state/apply_test.go
+++ b/internal/state/apply_test.go
@@ -36,7 +36,7 @@ func Test_buildSFnApplyResources(t *testing.T) {
 		s := &systemState{
 			instance: testInstalledServerless,
 			chartConfig: &chart.Config{
-				Cache: testEmptyManifestCache(),
+				Cache: fixEmptyManifestCache(),
 				CacheKey: types.NamespacedName{
 					Name:      testInstalledServerless.GetName(),
 					Namespace: testInstalledServerless.GetNamespace(),
@@ -68,10 +68,10 @@ func Test_buildSFnApplyResources(t *testing.T) {
 		s := &systemState{
 			instance: testInstalledServerless,
 			chartConfig: &chart.Config{
-				Cache: testEmptyManifestCache(),
+				Cache: fixManifestCache("\t"),
 				CacheKey: types.NamespacedName{
-					Name:      "does-not-exist",
-					Namespace: "test",
+					Name:      testInstalledServerless.GetName(),
+					Namespace: testInstalledServerless.GetNamespace(),
 				},
 			},
 		}

--- a/internal/state/delete_test.go
+++ b/internal/state/delete_test.go
@@ -66,7 +66,7 @@ func Test_sFnDeleteResources(t *testing.T) {
 		s := &systemState{
 			instance: testDeletingServerless,
 			chartConfig: &chart.Config{
-				Cache: testEmptyManifestCache(),
+				Cache: fixEmptyManifestCache(),
 				CacheKey: types.NamespacedName{
 					Name:      testDeletingServerless.GetName(),
 					Namespace: testDeletingServerless.GetNamespace(),
@@ -95,8 +95,11 @@ func Test_sFnDeleteResources(t *testing.T) {
 		s := &systemState{
 			instance: testDeletingServerless,
 			chartConfig: &chart.Config{
-				Cache:    testEmptyManifestCache(),
-				CacheKey: types.NamespacedName{},
+				Cache: fixManifestCache("\t"),
+				CacheKey: types.NamespacedName{
+					Name:      testInstalledServerless.GetName(),
+					Namespace: testInstalledServerless.GetNamespace(),
+				},
 			},
 		}
 
@@ -124,8 +127,11 @@ func Test_sFnDeleteResources(t *testing.T) {
 		s := &systemState{
 			instance: testDeletingServerless,
 			chartConfig: &chart.Config{
-				Cache:    testEmptyManifestCache(),
-				CacheKey: types.NamespacedName{},
+				Cache: fixManifestCache("\t"),
+				CacheKey: types.NamespacedName{
+					Name:      testInstalledServerless.GetName(),
+					Namespace: testInstalledServerless.GetNamespace(),
+				},
 			},
 		}
 
@@ -153,7 +159,7 @@ func Test_sFnDeleteResources(t *testing.T) {
 		s := &systemState{
 			instance: testDeletingServerless,
 			chartConfig: &chart.Config{
-				Cache: testEmptyManifestCache(),
+				Cache: fixEmptyManifestCache(),
 				CacheKey: types.NamespacedName{
 					Name:      testDeletingServerless.GetName(),
 					Namespace: testDeletingServerless.GetNamespace(),

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -44,12 +44,16 @@ var (
 	}
 )
 
-func testEmptyManifestCache() chart.ManifestCache {
+func fixEmptyManifestCache() chart.ManifestCache {
+	return fixManifestCache("")
+}
+
+func fixManifestCache(manifest string) chart.ManifestCache {
 	cache := chart.NewInMemoryManifestCache()
 	cache.Set(context.Background(), types.NamespacedName{
 		Name:      testInstalledServerless.GetName(),
 		Namespace: testInstalledServerless.GetNamespace(),
-	}, nil, "")
+	}, nil, manifest)
 
 	return cache
 }

--- a/internal/state/verify_test.go
+++ b/internal/state/verify_test.go
@@ -48,7 +48,7 @@ func Test_sFnVerifyResources(t *testing.T) {
 		s := &systemState{
 			instance: testInstalledServerless,
 			chartConfig: &chart.Config{
-				Cache: testEmptyManifestCache(),
+				Cache: fixEmptyManifestCache(),
 				CacheKey: types.NamespacedName{
 					Name:      testInstalledServerless.GetName(),
 					Namespace: testInstalledServerless.GetNamespace(),
@@ -81,8 +81,11 @@ func Test_sFnVerifyResources(t *testing.T) {
 		s := &systemState{
 			instance: testInstalledServerless,
 			chartConfig: &chart.Config{
-				Cache:    testEmptyManifestCache(),
-				CacheKey: types.NamespacedName{},
+				Cache: fixManifestCache("\t"),
+				CacheKey: types.NamespacedName{
+					Name:      testInstalledServerless.GetName(),
+					Namespace: testInstalledServerless.GetNamespace(),
+				},
 			},
 		}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- do not save data to cache every time after rendering a new manifest
- save manifest to cache only after applying resources to the cluster
- get or render manifest only before apply - in all states after apply get manifest from the cache only

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/118