### PR TITLE
Regenerate manifest when manager is changed

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVERLESS_MANAGER_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/chart/cache.go
+++ b/internal/chart/cache.go
@@ -73,6 +73,7 @@ type secretManifestCache struct {
 }
 
 type ServerlessSpecManifest struct {
+	ManagerUID  string
 	CustomFlags map[string]interface{}
 	Manifest    string
 }

--- a/internal/chart/install.go
+++ b/internal/chart/install.go
@@ -36,6 +36,7 @@ func Install(config *Config) error {
 	}
 
 	return config.Cache.Set(config.Ctx, config.CacheKey, ServerlessSpecManifest{
+		ManagerUID:  config.ManagerUID,
 		CustomFlags: config.Release.Flags,
 		Manifest:    manifest,
 	})

--- a/internal/state/fsm.go
+++ b/internal/state/fsm.go
@@ -28,9 +28,10 @@ var (
 type stateFn func(context.Context, *reconciler, *systemState) (stateFn, *ctrl.Result, error)
 
 type cfg struct {
-	finalizer string
-	chartPath string
-	namespace string
+	finalizer     string
+	chartPath     string
+	namespace     string
+	managerPodUID string
 }
 
 type systemState struct {

--- a/internal/state/fsm.go
+++ b/internal/state/fsm.go
@@ -76,10 +76,11 @@ func chartConfig(ctx context.Context, r *reconciler, s *systemState) (*chart.Con
 	}
 
 	return &chart.Config{
-		Ctx:      ctx,
-		Log:      r.log,
-		Cache:    r.cache,
-		CacheKey: secretCache,
+		Ctx:        ctx,
+		Log:        r.log,
+		Cache:      r.cache,
+		CacheKey:   secretCache,
+		ManagerUID: r.cfg.managerPodUID,
 		Cluster: chart.Cluster{
 			Client: r.client,
 			Config: r.config,

--- a/internal/state/new.go
+++ b/internal/state/new.go
@@ -27,9 +27,10 @@ func NewMachine(client client.Client, config *rest.Config, recorder record.Event
 		cache: cache,
 		log:   log,
 		cfg: cfg{
-			finalizer: v1alpha1.Finalizer,
-			chartPath: chartPath,
-			namespace: getEnvNamespace(),
+			finalizer:     v1alpha1.Finalizer,
+			chartPath:     chartPath,
+			namespace:     getEnvNamespace(),
+			managerPodUID: os.Getenv("SERVERLESS_MANAGER_UID"),
 		},
 		k8s: k8s{
 			client:        client,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add the `ManagerUID` field to the cache to inform the manager which pod rendered the manifest
- Regenerate manifest when manager's pod has other UID 

