### PR TITLE
Detect custom external docker registry

### DIFF
--- a/api/v1alpha1/serverless_types.go
+++ b/api/v1alpha1/serverless_types.go
@@ -51,6 +51,7 @@ type ConditionType string
 const (
 	StateReady      State = "Ready"
 	StateProcessing State = "Processing"
+	StateWarning    State = "Warning"
 	StateError      State = "Error"
 	StateDeleting   State = "Deleting"
 

--- a/api/v1alpha1/serverless_types.go
+++ b/api/v1alpha1/serverless_types.go
@@ -89,7 +89,7 @@ type ServerlessStatus struct {
 	// State signifies current state of Serverless.
 	// Value can be one of ("Ready", "Processing", "Error", "Deleting").
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Processing;Deleting;Ready;Error
+	// +kubebuilder:validation:Enum=Processing;Deleting;Ready;Error;Warning
 	State State `json:"state,omitempty"`
 
 	// Served signifies that current Serverless is managed.

--- a/config/crd/bases/operator.kyma-project.io_serverlesses.yaml
+++ b/config/crd/bases/operator.kyma-project.io_serverlesses.yaml
@@ -168,6 +168,7 @@ spec:
                 - Deleting
                 - Ready
                 - Error
+                - Warning
                 type: string
               tracingEndpoint:
                 type: string

--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -21,8 +21,8 @@ func DetectExternalRegistrySecrets(ctx context.Context, c client.Client) error {
 
 	var errMsgs []string
 	for _, secret := range secrets.Items {
-		errMsgs = append(errMsgs, fmt.Sprintf("name:%s, namespace %s", secret.Name, secret.Namespace))
+		errMsgs = append(errMsgs, fmt.Sprintf("found %s/%s secret", secret.Namespace, secret.Name))
 	}
 
-	return errors.Errorf("Secrets found: %s", strings.Join(errMsgs, ";"))
+	return errors.Errorf("additional registry configuration detected: %s", strings.Join(errMsgs, "; "))
 }

--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -1,7 +1,5 @@
 package registry
 
-import "errors"
-
 func ListExternalRegistrySecrets() error {
-	return errors.New("test error")
+	return nil
 }

--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -1,5 +1,28 @@
 package registry
 
-func ListExternalRegistrySecrets() error {
-	return nil
+import (
+	"context"
+	"fmt"
+	"github.com/go-errors/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+func DetectExternalRegistrySecrets(ctx context.Context, c client.Client) error {
+	secrets := corev1.SecretList{}
+	err := c.List(ctx, &secrets, client.MatchingLabels{"serverless.kyma-project.io/remote-registry": "config"})
+	if err != nil {
+		return err
+	}
+	if len(secrets.Items) == 0 {
+		return nil
+	}
+
+	var errMsgs []string
+	for _, secret := range secrets.Items {
+		errMsgs = append(errMsgs, fmt.Sprintf("name:%s, namespace %s", secret.Name, secret.Namespace))
+	}
+
+	return errors.Errorf("Secrets found: %s", strings.Join(errMsgs, ";"))
 }

--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -1,0 +1,7 @@
+package registry
+
+import "errors"
+
+func ListExternalRegistrySecrets() error {
+	return errors.New("test error")
+}

--- a/internal/registry/secret_test.go
+++ b/internal/registry/secret_test.go
@@ -1,14 +1,35 @@
 package registry
 
 import (
-	"github.com/stretchr/testify/require"
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testRegistrySecret = &corev1.Secret{
+		//TODO
+	}
 )
 
 func TestListExternalRegistrySecrets(t *testing.T) {
-
-	t.Run("returns error when external registry secret not found", func(t *testing.T) {
+	t.Run("returns nil when  external registry secret not found", func(t *testing.T) {
 		err := ListExternalRegistrySecrets()
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when found secrets", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := "kyma-test"
+		client := fake.NewClientBuilder().
+			WithRuntimeObjects(testRegistrySecret).
+			Build()
+
+		err := ListExternalRegistrySecrets(ctx, client, namespace)
 		require.Error(t, err)
+		require.ErrorContains(t, err, "TODO")
 	})
 }

--- a/internal/registry/secret_test.go
+++ b/internal/registry/secret_test.go
@@ -1,0 +1,14 @@
+package registry
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestListExternalRegistrySecrets(t *testing.T) {
+
+	t.Run("returns error when external registry secret not found", func(t *testing.T) {
+		err := ListExternalRegistrySecrets()
+		require.Error(t, err)
+	})
+}

--- a/internal/state/update_status.go
+++ b/internal/state/update_status.go
@@ -79,6 +79,16 @@ func sFnUpdateServedTrue() stateFn {
 	}
 }
 
+func sFnUpdateWarningState(condition v1alpha1.ConditionType, reason v1alpha1.ConditionReason, msg string) stateFn {
+	return func(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
+		s.setState(v1alpha1.StateWarning)
+		s.instance.UpdateConditionTrue(condition, reason, msg)
+
+		return updateServerlessStatus(buildSFnEmitEvent(sFnStop(), nil, nil), ctx, r, s)
+	}
+
+}
+
 func sFnUpdateServedFalse(condition v1alpha1.ConditionType, reason v1alpha1.ConditionReason, err error) stateFn {
 	return func(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
 		s.setServed(v1alpha1.ServedFalse)

--- a/internal/state/verify.go
+++ b/internal/state/verify.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"context"
+	"fmt"
+	"github.com/kyma-project/serverless-manager/internal/registry"
 
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
@@ -29,17 +31,16 @@ func sFnVerifyResources() stateFn {
 			return requeueAfter(requeueDuration)
 		}
 
-		//TODO check secrets
-
-		// if err != nil {
-		// return nextState(
-		// 	sFnUpdateWarningState(
-		// 		v1alpha1.ConditionTypeInstalled,
-		// 		v1alpha1.ConditionReasonInstalled,
-		// 		fmt.Sprintf("Warning: %s", err.Error()),
-		// 	),
-		// )
-		// }
+		err = registry.DetectExternalRegistrySecrets(ctx, r.client)
+		if err != nil {
+			return nextState(
+				sFnUpdateWarningState(
+					v1alpha1.ConditionTypeInstalled,
+					v1alpha1.ConditionReasonInstalled,
+					fmt.Sprintf("Warning: %s", err.Error()),
+				),
+			)
+		}
 
 		return nextState(
 			sFnUpdateReadyState(

--- a/internal/state/verify.go
+++ b/internal/state/verify.go
@@ -25,16 +25,28 @@ func sFnVerifyResources() stateFn {
 			)
 		}
 
-		if ready {
-			return nextState(
-				sFnUpdateReadyState(
-					v1alpha1.ConditionTypeInstalled,
-					v1alpha1.ConditionReasonInstalled,
-					"Serverless installed",
-				),
-			)
+		if !ready {
+			return requeueAfter(requeueDuration)
 		}
 
-		return requeueAfter(requeueDuration)
+		//TODO check secrets
+
+		// if err != nil {
+		// return nextState(
+		// 	sFnUpdateWarningState(
+		// 		v1alpha1.ConditionTypeInstalled,
+		// 		v1alpha1.ConditionReasonInstalled,
+		// 		fmt.Sprintf("Warning: %s", err.Error()),
+		// 	),
+		// )
+		// }
+
+		return nextState(
+			sFnUpdateReadyState(
+				v1alpha1.ConditionTypeInstalled,
+				v1alpha1.ConditionReasonInstalled,
+				"Serverless installed",
+			),
+		)
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Informs the user about existing external docker registry secret.

Changes proposed in this pull request:

- Adds a warning state to the FSM
- Add logic to detect the secrets and lists them in status message.

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/115
