### PR TITLE
Attempt to fix configCheckError

### DIFF
--- a/internal/state/verify.go
+++ b/internal/state/verify.go
@@ -26,6 +26,8 @@ func sFnVerifyResources() stateFn {
 		}
 
 		if ready {
+			//TODO: To be discussed how to do it in the proper way
+			s.instance.UpdateConditionTrue(v1alpha1.ConditionTypeConfigured, v1alpha1.ConditionReasonConfigured, "Serverless configured")
 			return nextState(
 				sFnUpdateReadyState(
 					v1alpha1.ConditionTypeInstalled,


### PR DESCRIPTION
**Description**
This PR fix the problem with Serverless CR does not recover from ConfigurationCheckErr condition after user corrects the configuration

Changes proposed in this pull request:

- update the configuration when the CR is ready to be installed

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/133
