### PR TITLE
fix configurationCheckErr

### DIFF
--- a/api/v1alpha1/serverless_helpers.go
+++ b/api/v1alpha1/serverless_helpers.go
@@ -16,6 +16,15 @@ func (s *Serverless) IsCondition(conditionType ConditionType) bool {
 	) != nil
 }
 
+func (s *Serverless) GetCondition(conditionType ConditionType) (metav1.Condition, bool) {
+	for _, condition := range s.Status.Conditions {
+		if condition.Type == string(conditionType) {
+			return condition, true
+		}
+	}
+	return metav1.Condition{}, false
+}
+
 func (s *Serverless) IsConditionTrue(conditionType ConditionType) bool {
 	condition := meta.FindStatusCondition(s.Status.Conditions, string(conditionType))
 	return condition != nil && condition.Status == metav1.ConditionTrue

--- a/internal/state/registry.go
+++ b/internal/state/registry.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
@@ -27,6 +28,18 @@ func sFnRegistryConfiguration(ctx context.Context, r *reconciler, s *systemState
 		}
 	default:
 		setK3dRegistry(s)
+	}
+
+	if condition, ok := s.instance.GetCondition(v1alpha1.ConditionTypeConfigured); ok {
+		if condition.Status == metav1.ConditionFalse {
+			s.setState(v1alpha1.StateReady)
+			s.instance.UpdateConditionTrue(
+				v1alpha1.ConditionTypeConfigured,
+				v1alpha1.ConditionReasonConfigured,
+				"Configured",
+			)
+			return nextState(sFnUpdateStatusAndRequeue)
+		}
 	}
 
 	if s.snapshot.DockerRegistry != s.instance.Status.DockerRegistry {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -81,3 +81,17 @@ func requireContainsCondition(t *testing.T, status v1alpha1.ServerlessStatus,
 	}
 	require.True(t, hasExpectedCondition)
 }
+
+func requireContainsConditionWithStatus(t *testing.T, status v1alpha1.ServerlessStatus,
+	conditionType v1alpha1.ConditionType, conditionStatus metav1.ConditionStatus, conditionReason v1alpha1.ConditionReason, conditionMessage string) {
+	hasExpectedCondition := false
+	for _, condition := range status.Conditions {
+		if condition.Type == string(conditionType) {
+			require.Equal(t, string(conditionReason), condition.Reason)
+			require.Equal(t, conditionStatus, condition.Status)
+			require.Equal(t, conditionMessage, condition.Message)
+			hasExpectedCondition = true
+		}
+	}
+	require.True(t, hasExpectedCondition)
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add function to get condition with given _conditionType_
- fix the problem with existing _ConfigurationError_ label even if the error does not exist anymore


**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/133
