### PR TITLE
set status.dockerRegistry from serverless cluster-wide external registry secret when it exists

### DIFF
--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -9,9 +9,17 @@ import (
 	"strings"
 )
 
+const (
+	ServerlessExternalRegistrySecretName             = "serverless-registry-config"
+	ServerlessExternalRegistryLabelRemoteRegistryKey = "serverless.kyma-project.io/remote-registry"
+	ServerlessExternalRegistryLabelRemoteRegistryVal = "config"
+	ServerlessExternalRegistryLabelConfigKey         = "serverless.kyma-project.io/config"
+	ServerlessExternalRegistryLabelConfigVal         = "credentials"
+)
+
 func DetectExternalRegistrySecrets(ctx context.Context, c client.Client) error {
 	secrets := corev1.SecretList{}
-	err := c.List(ctx, &secrets, client.MatchingLabels{"serverless.kyma-project.io/remote-registry": "config"})
+	err := c.List(ctx, &secrets, client.MatchingLabels{ServerlessExternalRegistryLabelRemoteRegistryKey: ServerlessExternalRegistryLabelRemoteRegistryVal})
 	if err != nil {
 		return err
 	}
@@ -27,11 +35,11 @@ func DetectExternalRegistrySecrets(ctx context.Context, c client.Client) error {
 	return errors.Errorf("additional registry configuration detected: %s", strings.Join(errMsgs, "; "))
 }
 
-func GetExternalRegistrySecret(ctx context.Context, c client.Client, namespace string) (*corev1.Secret, error) {
+func GetServerlessExternalRegistrySecret(ctx context.Context, c client.Client, namespace string) (*corev1.Secret, error) {
 	secret := corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: namespace,
-		Name:      "serverless-registry-config",
+		Name:      ServerlessExternalRegistrySecretName,
 	}
 	err := c.Get(ctx, key, &secret)
 	if err != nil {
@@ -41,10 +49,10 @@ func GetExternalRegistrySecret(ctx context.Context, c client.Client, namespace s
 	if secret.Type != corev1.SecretTypeDockerConfigJson {
 		return nil, nil
 	}
-	if val, ok := secret.GetLabels()["serverless.kyma-project.io/remote-registry"]; !ok || val != "config" {
+	if val, ok := secret.GetLabels()[ServerlessExternalRegistryLabelRemoteRegistryKey]; !ok || val != ServerlessExternalRegistryLabelRemoteRegistryVal {
 		return nil, nil
 	}
-	if val, ok := secret.GetLabels()["serverless.kyma-project.io/config"]; !ok || val != "credentials" {
+	if val, ok := secret.GetLabels()[ServerlessExternalRegistryLabelConfigKey]; !ok || val != ServerlessExternalRegistryLabelConfigVal {
 		return nil, nil
 	}
 

--- a/internal/registry/secret_test.go
+++ b/internal/registry/secret_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
@@ -14,16 +15,18 @@ var (
 	testRegistryEmptySecret  = &corev1.Secret{}
 	testRegistryFilledSecret = &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "secret",
+			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
+			Name:      "serverless-registry-config",
 			Namespace: "kyma-test",
 			Labels: map[string]string{
 				"serverless.kyma-project.io/remote-registry": "config",
+				"serverless.kyma-project.io/config":          "credentials",
 			},
 		},
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 )
 
@@ -48,4 +51,81 @@ func TestListExternalRegistrySecrets(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "test-secret")
 	})
+}
+
+func Test_GetExternalRegistrySecret(t *testing.T) {
+	t.Run("returns nil when external registry secret not found", func(t *testing.T) {
+		ctx := context.Background()
+		client := fake.NewClientBuilder().
+			Build()
+		namespace := "some-namespace"
+
+		secret, err := GetExternalRegistrySecret(ctx, client, namespace)
+		require.NoError(t, err)
+		require.Nil(t, secret)
+	})
+
+	t.Run("returns secret when found it", func(t *testing.T) {
+		ctx := context.Background()
+		client := fake.NewClientBuilder().
+			WithRuntimeObjects(testRegistryFilledSecret).
+			Build()
+		namespace := testRegistryFilledSecret.Namespace
+
+		secret, err := GetExternalRegistrySecret(ctx, client, namespace)
+		require.NoError(t, err)
+		require.NotNil(t, secret)
+		require.Equal(t, testRegistryFilledSecret, secret)
+	})
+
+	noProperSecretTests := []struct {
+		name                string
+		secretInEnvironment *corev1.Secret
+	}{
+		{
+			name: "bad name",
+			secretInEnvironment: func() *corev1.Secret {
+				secret := testRegistryFilledSecret.DeepCopy()
+				secret.Name = "bad-name"
+				return secret
+			}(),
+		},
+		{
+			name: "bad type",
+			secretInEnvironment: func() *corev1.Secret {
+				secret := testRegistryFilledSecret.DeepCopy()
+				secret.Type = corev1.SecretTypeBasicAuth
+				return secret
+			}(),
+		},
+		{
+			name: "without label remote-registry",
+			secretInEnvironment: func() *corev1.Secret {
+				secret := testRegistryFilledSecret.DeepCopy()
+				delete(secret.Labels, "serverless.kyma-project.io/remote-registry")
+				return secret
+			}(),
+		},
+		{
+			name: "without label config",
+			secretInEnvironment: func() *corev1.Secret {
+				secret := testRegistryFilledSecret.DeepCopy()
+				delete(secret.Labels, "serverless.kyma-project.io/config")
+				return secret
+			}(),
+		},
+	}
+	for _, tt := range noProperSecretTests {
+		t.Run(fmt.Sprintf("returns nil when no secret has proper params - %s", tt.name), func(t *testing.T) {
+			ctx := context.Background()
+			client := fake.NewClientBuilder().
+				WithObjects(tt.secretInEnvironment).
+				Build()
+			namespace := testRegistryFilledSecret.Namespace
+
+			secret, err := GetExternalRegistrySecret(ctx, client, namespace)
+			require.NoError(t, err)
+			require.Nil(t, secret)
+		})
+	}
 }

--- a/internal/registry/secret_test.go
+++ b/internal/registry/secret_test.go
@@ -49,7 +49,7 @@ func TestListExternalRegistrySecrets(t *testing.T) {
 
 		err := DetectExternalRegistrySecrets(ctx, client)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "test-secret")
+		require.ErrorContains(t, err, testRegistryFilledSecret.Name)
 	})
 }
 

--- a/internal/registry/test_helpers.go
+++ b/internal/registry/test_helpers.go
@@ -1,0 +1,28 @@
+package registry
+
+import (
+	"k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func FixServerlessClusterWideExternalRegistrySecret() *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      ServerlessExternalRegistrySecretName,
+			Namespace: "kyma-test",
+			Labels: map[string]string{
+				ServerlessExternalRegistryLabelRemoteRegistryKey: ServerlessExternalRegistryLabelRemoteRegistryVal,
+				ServerlessExternalRegistryLabelConfigKey:         ServerlessExternalRegistryLabelConfigVal,
+			},
+		},
+		Type: v1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			"registryAddress": []byte("test-registry-address"),
+			"serverAddress":   []byte("test-server-address"),
+		},
+	}
+}

--- a/internal/state/registry.go
+++ b/internal/state/registry.go
@@ -52,13 +52,13 @@ func sFnRegistryConfiguration(ctx context.Context, r *reconciler, s *systemState
 
 func setExternalRegistrySecretNameInDockerRegistryStatus(ctx context.Context, r *reconciler, s *systemState) {
 	// doc: https://kyma-project.io/docs/kyma/latest/05-technical-reference/svls-03-switching-registries#cluster-wide-external-registry
-	secret, err := registry.GetExternalRegistrySecret(ctx, r.client, s.instance.GetNamespace())
+	secret, err := registry.GetServerlessExternalRegistrySecret(ctx, r.client, s.instance.GetNamespace())
 	// ignore errors because it only set status
 	if err != nil || secret == nil {
 		return
 	}
-	if registryAddress, ok := secret.Data["registryAddress"]; ok {
-		s.instance.Status.DockerRegistry = string(registryAddress)
+	if address, ok := secret.Data["serverAddress"]; ok {
+		s.instance.Status.DockerRegistry = string(address)
 	}
 	return
 }

--- a/internal/state/registry_test.go
+++ b/internal/state/registry_test.go
@@ -121,6 +121,9 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 	t.Run("k3d registry and update", func(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.Serverless{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "some-namespace",
+				},
 				Spec: v1alpha1.ServerlessSpec{
 					DockerRegistry: &v1alpha1.DockerRegistry{
 						EnableInternal: pointer.Bool(false),
@@ -136,6 +139,11 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 				},
 			},
 		}
+		r := &reconciler{
+			k8s: k8s{
+				client: fake.NewClientBuilder().Build(),
+			},
+		}
 		expectedFlags := map[string]interface{}{
 			"dockerRegistry": map[string]interface{}{
 				"enableInternal":  false,
@@ -145,7 +153,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 		}
 		expectedNext := sFnUpdateStatusAndRequeue
 
-		next, result, err := sFnRegistryConfiguration(context.Background(), nil, s)
+		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
 		require.Nil(t, result)
 		require.NoError(t, err)
 		requireEqualFunc(t, expectedNext, next)
@@ -156,6 +164,9 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 	t.Run("external registry secret not found error", func(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.Serverless{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "some-namespace",
+				},
 				Spec: v1alpha1.ServerlessSpec{
 					DockerRegistry: &v1alpha1.DockerRegistry{
 						EnableInternal: pointer.Bool(false),
@@ -184,5 +195,54 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 			v1alpha1.ConditionReasonConfigurationErr,
 			"secrets \"test-secret-not-found\" not found",
 		)
+	})
+	t.Run("overwrite docker registry status when exists serverless cluster-wide external registry secret", func(t *testing.T) {
+		serverlessClusterWideExternalRegistrySecret := fixServerlessClusterWideExternalRegistrySecret()
+		s := &systemState{
+			instance: v1alpha1.Serverless{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: serverlessClusterWideExternalRegistrySecret.Namespace,
+				},
+				Spec: v1alpha1.ServerlessSpec{
+					DockerRegistry: &v1alpha1.DockerRegistry{
+						EnableInternal: pointer.Bool(true),
+					},
+				},
+			},
+			snapshot: v1alpha1.ServerlessStatus{
+				DockerRegistry: "",
+			},
+			chartConfig: &chart.Config{
+				Release: chart.Release{
+					Flags: chart.EmptyFlags(),
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().
+			WithObjects(serverlessClusterWideExternalRegistrySecret).
+			Build()
+		r := &reconciler{
+			k8s: k8s{client: client},
+			log: zap.NewNop().Sugar(),
+		}
+
+		expectedFlags := map[string]interface{}{
+			"dockerRegistry": map[string]interface{}{
+				"enableInternal": true,
+			},
+			"global": map[string]interface{}{
+				"registryNodePort": int64(32_137),
+			},
+		}
+		expectedNext := sFnUpdateStatusAndRequeue
+
+		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
+		require.Nil(t, result)
+		require.NoError(t, err)
+		requireEqualFunc(t, expectedNext, next)
+
+		require.EqualValues(t, expectedFlags, s.chartConfig.Release.Flags)
+		require.Equal(t, string(serverlessClusterWideExternalRegistrySecret.Data["registryAddress"]), s.instance.Status.DockerRegistry)
 	})
 }

--- a/internal/state/registry_test.go
+++ b/internal/state/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
+	"github.com/kyma-project/serverless-manager/internal/registry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -197,7 +198,7 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 		)
 	})
 	t.Run("overwrite docker registry status when exists serverless cluster-wide external registry secret", func(t *testing.T) {
-		serverlessClusterWideExternalRegistrySecret := fixServerlessClusterWideExternalRegistrySecret()
+		serverlessClusterWideExternalRegistrySecret := registry.FixServerlessClusterWideExternalRegistrySecret()
 		s := &systemState{
 			instance: v1alpha1.Serverless{
 				ObjectMeta: metav1.ObjectMeta{
@@ -243,6 +244,6 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 		requireEqualFunc(t, expectedNext, next)
 
 		require.EqualValues(t, expectedFlags, s.chartConfig.Release.Flags)
-		require.Equal(t, string(serverlessClusterWideExternalRegistrySecret.Data["registryAddress"]), s.instance.Status.DockerRegistry)
+		require.Equal(t, string(serverlessClusterWideExternalRegistrySecret.Data["serverAddress"]), s.instance.Status.DockerRegistry)
 	})
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"reflect"
 	"runtime"
 	"testing"
@@ -81,4 +82,25 @@ func requireContainsCondition(t *testing.T, status v1alpha1.ServerlessStatus,
 		}
 	}
 	require.True(t, hasExpectedCondition)
+}
+
+func fixServerlessClusterWideExternalRegistrySecret() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "serverless-registry-config",
+			Namespace: "kyma-test",
+			Labels: map[string]string{
+				"serverless.kyma-project.io/remote-registry": "config",
+				"serverless.kyma-project.io/config":          "credentials",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			"registryAddress": []byte("test-registry-address"),
+		},
+	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -3,7 +3,6 @@ package state
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"reflect"
 	"runtime"
 	"testing"
@@ -82,25 +81,4 @@ func requireContainsCondition(t *testing.T, status v1alpha1.ServerlessStatus,
 		}
 	}
 	require.True(t, hasExpectedCondition)
-}
-
-func fixServerlessClusterWideExternalRegistrySecret() *corev1.Secret {
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "serverless-registry-config",
-			Namespace: "kyma-test",
-			Labels: map[string]string{
-				"serverless.kyma-project.io/remote-registry": "config",
-				"serverless.kyma-project.io/config":          "credentials",
-			},
-		},
-		Type: corev1.SecretTypeDockerConfigJson,
-		Data: map[string][]byte{
-			"registryAddress": []byte("test-registry-address"),
-		},
-	}
 }

--- a/internal/state/verify_test.go
+++ b/internal/state/verify_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"errors"
+	"github.com/kyma-project/serverless-manager/internal/registry"
 	"testing"
 
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
@@ -31,19 +32,7 @@ var (
 			},
 		},
 	}
-	testRegistryFilledSecret = &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
-			Namespace: "kyma-test",
-			Labels: map[string]string{
-				"serverless.kyma-project.io/remote-registry": "config",
-			},
-		},
-	}
+	testRegistryFilledSecret = registry.FixServerlessClusterWideExternalRegistrySecret()
 )
 
 const (
@@ -128,7 +117,7 @@ func Test_sFnVerifyResources(t *testing.T) {
 			v1alpha1.ConditionTypeInstalled,
 			metav1.ConditionTrue,
 			v1alpha1.ConditionReasonInstalled,
-			"Warning: additional registry configuration detected: found kyma-test/test-secret secret",
+			"Warning: additional registry configuration detected: found kyma-test/serverless-registry-config secret",
 		)
 	})
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- set status.dockerRegistry from serverless cluster-wide external registry secret when it exists

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #137 
