### PR TITLE
Remove checking external registry secret type

### DIFF
--- a/internal/registry/secret.go
+++ b/internal/registry/secret.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,9 +26,6 @@ func GetServerlessExternalRegistrySecret(ctx context.Context, c client.Client, n
 		return nil, client.IgnoreNotFound(err)
 	}
 
-	if secret.Type != corev1.SecretTypeDockerConfigJson {
-		return nil, nil
-	}
 	if val, ok := secret.GetLabels()[ServerlessExternalRegistryLabelRemoteRegistryKey]; !ok || val != ServerlessExternalRegistryLabelRemoteRegistryVal {
 		return nil, nil
 	}

--- a/internal/registry/secret_test.go
+++ b/internal/registry/secret_test.go
@@ -53,14 +53,6 @@ func Test_GetExternalRegistrySecret(t *testing.T) {
 			}(),
 		},
 		{
-			name: "bad type",
-			secretInEnvironment: func() *corev1.Secret {
-				secret := testRegistryFilledSecret.DeepCopy()
-				secret.Type = corev1.SecretTypeBasicAuth
-				return secret
-			}(),
-		},
-		{
 			name: "without label remote-registry",
 			secretInEnvironment: func() *corev1.Secret {
 				secret := testRegistryFilledSecret.DeepCopy()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- serverless component does not require the specific type of external registry secret - operator should not require the specific type as well

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/115#issuecomment-1647674693