### PR TITLE
Bump golang runtime to 1.20.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM golang:1.19.1 as builder
+FROM golang:1.20.7 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use latest stable golamg-runtime version

