### PR TITLE
Fix Tracing & Eventing Endpoints Defaulting

### DIFF
--- a/api/v1alpha1/serverless_helpers.go
+++ b/api/v1alpha1/serverless_helpers.go
@@ -22,10 +22,11 @@ func (s *Serverless) IsConditionTrue(conditionType ConditionType) bool {
 }
 
 const (
-	DefaultEnableInternal  = false
-	DefaultRegistryAddress = "k3d-kyma-registry:5000"
-	DefaultServerAddress   = "k3d-kyma-registry:5000"
-	FeatureDisabled        = "disabled"
+	DefaultEnableInternal   = false
+	DefaultRegistryAddress  = "k3d-kyma-registry:5000"
+	DefaultServerAddress    = "k3d-kyma-registry:5000"
+	FeatureDisabled         = ""
+	DefaultEventingEndpoint = "http://eventing-publisher-proxy.kyma-system.svc.cluster.local/publish"
 )
 
 func (s *ServerlessSpec) Default() {

--- a/controllers/serverless_controller_test.go
+++ b/controllers/serverless_controller_test.go
@@ -24,9 +24,8 @@ var _ = Describe("Serverless controller", func() {
 
 		var (
 			serverlessDataDefault = serverlessData{
-				EventPublisherProxyURL: pointer.String(v1alpha1.FeatureDisabled),
-				TraceCollectorURL:      pointer.String(v1alpha1.FeatureDisabled),
-				EnableInternal:         pointer.Bool(v1alpha1.DefaultEnableInternal),
+				TraceCollectorURL: pointer.String(v1alpha1.FeatureDisabled),
+				EnableInternal:    pointer.Bool(v1alpha1.DefaultEnableInternal),
 				registrySecretData: registrySecretData{
 					ServerAddress:   pointer.String(v1alpha1.DefaultServerAddress),
 					RegistryAddress: pointer.String(v1alpha1.DefaultRegistryAddress),

--- a/controllers/testhelper_test.go
+++ b/controllers/testhelper_test.go
@@ -307,7 +307,7 @@ func (h *testHelper) createCheckOptionalDependenciesFunc(deploymentName string, 
 			return ok, err
 		}
 
-		eventProxyURL := v1alpha1.FeatureDisabled
+		eventProxyURL := v1alpha1.DefaultEventingEndpoint
 		if expected.EventPublisherProxyURL != nil {
 			eventProxyURL = *expected.EventPublisherProxyURL
 		}

--- a/internal/state/optional_dependencies.go
+++ b/internal/state/optional_dependencies.go
@@ -79,7 +79,7 @@ func getEventingURL(spec v1alpha1.ServerlessSpec) string {
 		}
 		return spec.Eventing.Endpoint
 	}
-	return v1alpha1.FeatureDisabled
+	return v1alpha1.DefaultEventingEndpoint
 }
 
 // returns "custom" or "no" based on args
@@ -87,6 +87,8 @@ func dependencyState(url string) string {
 	switch {
 	case url == "" || url == v1alpha1.FeatureDisabled:
 		return "no"
+	case url == v1alpha1.DefaultEventingEndpoint:
+		return "default"
 	default:
 		return "custom"
 	}

--- a/internal/state/optional_dependencies_test.go
+++ b/internal/state/optional_dependencies_test.go
@@ -26,6 +26,7 @@ func Test_sFnOptionalDependencies(t *testing.T) {
 	configuredMsg := "Configured with custom Publisher Proxy URL and custom Trace Collector URL."
 	noConfigurationMsg := "Configured with no Publisher Proxy URL and no Trace Collector URL."
 	traceConfiguredMsg := "Configured with no Publisher Proxy URL and custom Trace Collector URL."
+	defaultEventingConfigurationMsg := "Configured with default Publisher Proxy URL and no Trace Collector URL."
 
 	testCases := map[string]struct {
 		tracing               *v1alpha1.Endpoint
@@ -50,9 +51,9 @@ func Test_sFnOptionalDependencies(t *testing.T) {
 			expectedStatusMessage: traceConfiguredMsg,
 		},
 		"Tracing is not set, TracePipeline svc is not available": {
-			expectedEventingURL:   v1alpha1.FeatureDisabled,
+			expectedEventingURL:   v1alpha1.DefaultEventingEndpoint,
 			expectedTracingURL:    v1alpha1.FeatureDisabled,
-			expectedStatusMessage: noConfigurationMsg,
+			expectedStatusMessage: defaultEventingConfigurationMsg,
 		},
 		"Tracing and eventing is disabled": {
 			tracing:               &v1alpha1.Endpoint{Endpoint: ""},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- default eventing endpoint should be `http://eventing-publisher-proxy.kyma-system.svc.cluster.local/publish`
- in case endpoints are deliberately disabled, pass on empty string to the function runtime pods

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/168