### PR TITLE
Propagate default presets to webhook overrides

### DIFF
--- a/config/ui-extensions/serverless/details
+++ b/config/ui-extensions/serverless/details
@@ -26,6 +26,33 @@ body:
       - name: OTLP Trace Endpoint
         source: spec.tracing.endpoint
         visibility: '$exists($value)'
+      - name: Default Resources Preset (Build-time)
+        source: spec.defaultBuildJobPreset
+        visibility: '$exists($value)'
+      - name: Default Resources Preset (Runtime)
+        source: spec.defaultRuntimePodPreset
+        visibility: '$exists($value)'
+      - name: Custom Build Execution Args
+        source: spec.functionBuildExecutorArgs
+        visibility: '$exists($value)'
+      - name: Max Simultaneous Builds 
+        source: spec.functionBuildMaxSimultaneousJobs
+        visibility: '$exists($value)'
+      - name: Function Request Body Limit [Mb]
+        source: spec.functionRequestBodyLimitMb
+        visibility: '$exists($value)'
+      - name: Function Timeout [Sec]
+        source: spec.functionTimeoutSec
+        visibility: '$exists($value)'
+      - name: Function Requeue Duration
+        source: spec.functionRequeueDuration
+        visibility: '$exists($value)'
+      - name: Controller Liveness Timeout
+        source: spec.healthzLivenessTimeout
+        visibility: '$exists($value)'
+      - name: Target CPU utilisation for HPA
+        source: spec.targetCPUUtilizationPercentage
+        visibility: '$exists($value)'
   - name: Status
     widget: Panel
     children:

--- a/internal/chart/flags.go
+++ b/internal/chart/flags.go
@@ -1,6 +1,6 @@
 package chart
 
-func AppendContainersFlags(flags map[string]interface{}, publisherURL, traceCollectorURL, CPUUtilizationPercentage, requeueDuration, buildExecutorArgs, maxSimultaneousJobs, healthzLivenessTimeout, requestBodyLimitMb, timeoutSec, defaultBuildJobPreset, defaultRuntimePodPreset string) map[string]interface{} {
+func AppendContainersFlags(flags map[string]interface{}, publisherURL, traceCollectorURL, CPUUtilizationPercentage, requeueDuration, buildExecutorArgs, maxSimultaneousJobs, healthzLivenessTimeout, requestBodyLimitMb, timeoutSec string) map[string]interface{} {
 	flags["containers"] = map[string]interface{}{
 		"manager": map[string]interface{}{
 			"envs": map[string]interface{}{
@@ -17,8 +17,6 @@ func AppendContainersFlags(flags map[string]interface{}, publisherURL, traceColl
 				"healthzLivenessTimeout":           getValueOrEmpty(healthzLivenessTimeout),
 				"functionRequestBodyLimitMb":       getValueOrEmpty(requestBodyLimitMb),
 				"functionTimeoutSec":               getValueOrEmpty(timeoutSec),
-				"defaultBuildJobPreset":            getValueOrEmpty(defaultBuildJobPreset),
-				"defaultRuntimePodPreset":          getValueOrEmpty(defaultRuntimePodPreset),
 			},
 		},
 	}
@@ -69,6 +67,33 @@ func AppendExternalRegistryFlags(flags map[string]interface{}, enableInternal bo
 		"password":        password,
 		"registryAddress": registryAddress,
 		"serverAddress":   serverAddress,
+	}
+
+	return flags
+}
+
+func AppendDefaultPresetFlags(flags map[string]interface{}, defaultBuildJobPreset, defaultRuntimePodPreset string) map[string]interface{} {
+
+	values := map[string]interface{}{}
+
+	if defaultRuntimePodPreset != "" {
+		values["function"] = map[string]interface{}{
+			"resources": map[string]interface{}{
+				"defaultPreset": defaultRuntimePodPreset,
+			},
+		}
+	}
+
+	if defaultBuildJobPreset != "" {
+		values["buildJob"] = map[string]interface{}{
+			"resources": map[string]interface{}{
+				"defaultPreset": defaultBuildJobPreset,
+			},
+		}
+	}
+
+	flags["webhook"] = map[string]interface{}{
+		"values": values,
 	}
 
 	return flags

--- a/internal/state/optional_dependencies.go
+++ b/internal/state/optional_dependencies.go
@@ -3,6 +3,8 @@ package state
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
 	"github.com/kyma-project/serverless-manager/internal/tracing"
@@ -12,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 // enable or disable serverless optional dependencies based on the Serverless Spec and installed module on the cluster
@@ -57,6 +58,10 @@ func sFnOptionalDependencies(ctx context.Context, r *reconciler, s *systemState)
 		s.instance.Status.HealthzLivenessTimeout,
 		s.instance.Status.RequestBodyLimitMb,
 		s.instance.Status.TimeoutSec,
+	)
+
+	s.chartConfig.Release.Flags = chart.AppendDefaultPresetFlags(
+		s.chartConfig.Release.Flags,
 		s.instance.Status.DefaultBuildJobPreset,
 		s.instance.Status.DefaultRuntimePodPreset,
 	)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Propagate presets as webhook overrides
- Show overriden values on serverless CR details view in busola

**Related issue(s)**
#105 