### PR TITLE
Adjust SetupWithManager to be reconciled max after 5 min

### DIFF
--- a/controllers/testhelper_test.go
+++ b/controllers/testhelper_test.go
@@ -68,7 +68,7 @@ func (h *testHelper) updateDeploymentStatus(deploymentName string) {
 	var deployment appsv1.Deployment
 	Eventually(h.createGetKubernetesObjectFunc(deploymentName, &deployment)).
 		WithPolling(time.Second * 2).
-		WithTimeout(time.Second * 30).
+		WithTimeout(time.Second * 90).
 		Should(BeTrue())
 
 	deployment.Status.Conditions = append(deployment.Status.Conditions, appsv1.DeploymentCondition{


### PR DESCRIPTION

Changes proposed in this pull request:

- Change max time of reconcilation to 5 min


**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/87
