### PR TITLE
Get rid of main in release runs

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Verify serverless manifest images
         run: ./scripts/verify-serverless-manifest-images.sh
 
-  verify-main-status:
-    name: Verify main
+  verify-head-status:
+    name: Verify HEAD
     needs: verify-serverless-manifest-images
     runs-on: ubuntu-latest
 
@@ -47,12 +47,12 @@ jobs:
 
   run-unit-tests:
     name: Unit tests
-    needs: verify-main-status
+    needs: verify-head-status
     uses: "./.github/workflows/run-unit-tests.yaml"
 
   create-draft:
     name: Create draft release
-    needs: verify-main-status
+    needs: verify-head-status
     runs-on: ubuntu-latest
 
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [verify-main-status, create-draft, run-unit-tests]
+    needs: [verify-head-status, create-draft, run-unit-tests]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- rename missing workflow runs that are working on the HEAD (not main)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/186