### PR TITLE
Set Warning state when orphaned functions found at deletion

### DIFF
--- a/internal/state/delete.go
+++ b/internal/state/delete.go
@@ -63,7 +63,7 @@ func sFnUpstreamDeletionState(_ context.Context, r *reconciler, s *systemState) 
 func sFnSafeDeletionState(_ context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
 	if err := chart.CheckCRDOrphanResources(s.chartConfig); err != nil {
 		// stop state machine with an error and requeue reconciliation in 1min
-		s.setState(v1alpha1.StateError)
+		s.setState(v1alpha1.StateWarning)
 		s.instance.UpdateConditionFalse(
 			v1alpha1.ConditionTypeDeleted,
 			v1alpha1.ConditionReasonDeletionErr,

--- a/internal/state/delete.go
+++ b/internal/state/delete.go
@@ -62,7 +62,8 @@ func sFnUpstreamDeletionState(_ context.Context, r *reconciler, s *systemState) 
 
 func sFnSafeDeletionState(_ context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
 	if err := chart.CheckCRDOrphanResources(s.chartConfig); err != nil {
-		// stop state machine with an error and requeue reconciliation in 1min
+		// stop state machine with a warning and requeue reconciliation in 1min
+		// warning state indicates that user intervention would fix it. Its not reconciliation error.
 		s.setState(v1alpha1.StateWarning)
 		s.instance.UpdateConditionFalse(
 			v1alpha1.ConditionTypeDeleted,

--- a/internal/state/delete_test.go
+++ b/internal/state/delete_test.go
@@ -156,7 +156,7 @@ func Test_sFnDeleteResources(t *testing.T) {
 		require.Nil(t, err)
 
 		status := s.instance.Status
-		require.Equal(t, v1alpha1.StateError, status.State)
+		require.Equal(t, v1alpha1.StateWarning, status.State)
 		requireContainsCondition(t, status,
 			v1alpha1.ConditionTypeDeleted,
 			metav1.ConditionFalse,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- When user intervention is needed, status of the module should be set to Warning.


**Related issue(s)**
https://github.com/kyma-project/lifecycle-manager/issues/525
https://github.com/kyma-project/serverless-manager/issues/259