### PR TITLE
add removing orphaned config maps and secrets

### DIFF
--- a/internal/state/delete_test.go
+++ b/internal/state/delete_test.go
@@ -2,6 +2,10 @@ package state
 
 import (
 	"errors"
+	v1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
@@ -28,6 +32,9 @@ var (
 )
 
 func Test_sFnDeleteResources(t *testing.T) {
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}
+	lease := v1.Lease{ObjectMeta: metav1.ObjectMeta{Name: "c9a95105.kyma-project.io", Namespace: "kyma-system"}}
+
 	t.Run("update condition", func(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.Serverless{},
@@ -71,6 +78,13 @@ func Test_sFnDeleteResources(t *testing.T) {
 				CacheKey: types.NamespacedName{
 					Name:      testDeletingServerless.GetName(),
 					Namespace: testDeletingServerless.GetNamespace(),
+				},
+				Cluster: chart.Cluster{
+					Client: fake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithObjects(&ns).
+						WithObjects(&lease).
+						Build(),
 				},
 			},
 		}
@@ -176,6 +190,13 @@ func Test_sFnDeleteResources(t *testing.T) {
 				CacheKey: types.NamespacedName{
 					Name:      testDeletingServerless.GetName(),
 					Namespace: testDeletingServerless.GetNamespace(),
+				},
+				Cluster: chart.Cluster{
+					Client: fake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithObjects(&ns).
+						WithObjects(&lease).
+						Build(),
 				},
 			},
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add removing orphaned resources (config maps, secrets, service accounts, lease) when we remove Serverless

**Related issue(s)**
See also: #264