### PR TITLE
Use latest available k8s version in gardener test

### DIFF
--- a/hack/common/Makefile
+++ b/hack/common/Makefile
@@ -75,10 +75,17 @@ delete-k3d-cluster: ## Delete k3d kyma cluster.
 
 HIBERNATION_HOUR=$(shell echo $$(( ( $(shell date +%H | sed s/^0//g) + 5 ) % 24 )))
 GIT_COMMIT_SHA=$(shell git rev-parse --short=8 HEAD)
+ifeq (,$(GARDENER_K8S_VERSION))
+ifneq (,$(GARDENER_SA_PATH))
+GARDENER_K8S_VERSION=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
+else
+GARDENER_K8S_VERSION=1.27.4
+endif
+endif
 
 .PHONY: provision-gardener
-provision-gardener: kyma ## Provision gardener cluster
-	${KYMA} provision gardener ${GARDENER_INFRASTRUCTURE} -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} \
+provision-gardener: kyma ## Provision gardener cluster with latest k8s version
+	${KYMA} provision gardener ${GARDENER_INFRASTRUCTURE} -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION}\
 		--hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
 
 .PHONY: deprovision-gardener

--- a/hack/common/Makefile
+++ b/hack/common/Makefile
@@ -75,12 +75,10 @@ delete-k3d-cluster: ## Delete k3d kyma cluster.
 
 HIBERNATION_HOUR=$(shell echo $$(( ( $(shell date +%H | sed s/^0//g) + 5 ) % 24 )))
 GIT_COMMIT_SHA=$(shell git rev-parse --short=8 HEAD)
-ifeq (,$(GARDENER_K8S_VERSION))
 ifneq (,$(GARDENER_SA_PATH))
-GARDENER_K8S_VERSION=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
+GARDENER_K8S_VERSION?=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud ${GARDENER_INFRASTRUCTURE} -o=jsonpath='{.spec.kubernetes.versions[0].version}')
 else
-GARDENER_K8S_VERSION=1.27.4
-endif
+GARDENER_K8S_VERSION?=1.27.4
 endif
 
 .PHONY: provision-gardener


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fetch latest available k8s version and use it when setting up test cluster in gardener tests

**Related issue(s)**
Fixes #43 