### PR TITLE
Use requeueAfter secret are deleted

### DIFF
--- a/internal/state/delete.go
+++ b/internal/state/delete.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"time"
 
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
@@ -97,7 +98,9 @@ func deleteResourcesWithFilter(r *reconciler, s *systemState, filterFuncs ...cha
 			v1alpha1.ConditionReasonDeletion,
 			"Deleting secrets",
 		)
-		return requeue()
+
+		// wait one sec until ctrl-mngr remove finalizers from secrets
+		return requeueAfter(time.Second)
 	}
 
 	if err := chart.Uninstall(s.chartConfig, filterFuncs...); err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- use the `requeueAfter` to not face back-off delay

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/219