### PR TITLE
Rename the `stopWithError` func

### DIFF
--- a/internal/state/apply.go
+++ b/internal/state/apply.go
@@ -29,7 +29,7 @@ func sFnApplyResources(_ context.Context, r *reconciler, s *systemState) (stateF
 			v1alpha1.ConditionReasonInstallationErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	// switch state verify

--- a/internal/state/delete.go
+++ b/internal/state/delete.go
@@ -69,7 +69,7 @@ func sFnSafeDeletionState(_ context.Context, r *reconciler, s *systemState) (sta
 			v1alpha1.ConditionReasonDeletionErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	return deleteResourcesWithFilter(r, s)
@@ -88,7 +88,7 @@ func deleteResourcesWithFilter(r *reconciler, s *systemState, filterFuncs ...cha
 			v1alpha1.ConditionReasonDeletionErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 	if !done {
 		s.setState(v1alpha1.StateDeleting)
@@ -109,7 +109,7 @@ func deleteResourcesWithFilter(r *reconciler, s *systemState, filterFuncs ...cha
 			v1alpha1.ConditionReasonDeletionErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	if !s.instance.IsConditionTrue(v1alpha1.ConditionTypeDeleted) {

--- a/internal/state/registry.go
+++ b/internal/state/registry.go
@@ -29,7 +29,7 @@ func sFnRegistryConfiguration(ctx context.Context, r *reconciler, s *systemState
 			v1alpha1.ConditionReasonConfigurationErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	return nextState(sFnOptionalDependencies)

--- a/internal/state/remove_finalizer.go
+++ b/internal/state/remove_finalizer.go
@@ -13,5 +13,5 @@ func sFnRemoveFinalizer(ctx context.Context, r *reconciler, s *systemState) (sta
 	}
 
 	err := updateServerlessWithoutStatus(ctx, r, s)
-	return stopWithError(err)
+	return stopWithPossibleError(err)
 }

--- a/internal/state/served_filter.go
+++ b/internal/state/served_filter.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -11,7 +12,7 @@ func sFnServedFilter(ctx context.Context, r *reconciler, s *systemState) (stateF
 	if s.instance.IsServedEmpty() {
 		servedServerless, err := GetServedServerless(ctx, r.k8s.client)
 		if err != nil {
-			return stopWithError(err)
+			return stopWithPossibleError(err)
 		}
 
 		if servedServerless == nil {
@@ -27,7 +28,7 @@ func sFnServedFilter(ctx context.Context, r *reconciler, s *systemState) (stateF
 			v1alpha1.ConditionReasonServerlessDuplicated,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	if s.instance.Status.Served == v1alpha1.ServedFalse {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,7 +18,7 @@ func nextState(next stateFn) (stateFn, *ctrl.Result, error) {
 	return next, nil, nil
 }
 
-func stopWithError(err error) (stateFn, *ctrl.Result, error) {
+func stopWithPossibleError(err error) (stateFn, *ctrl.Result, error) {
 	return nil, nil, err
 }
 

--- a/internal/state/verify.go
+++ b/internal/state/verify.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+
 	"github.com/kyma-project/serverless-manager/api/v1alpha1"
 	"github.com/kyma-project/serverless-manager/internal/chart"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,7 +21,7 @@ func sFnVerifyResources(_ context.Context, r *reconciler, s *systemState) (state
 			v1alpha1.ConditionReasonInstallationErr,
 			err,
 		)
-		return stopWithError(err)
+		return stopWithPossibleError(err)
 	}
 
 	if !ready {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- according to the [following discussion](https://github.com/kyma-project/serverless-manager/pull/272#discussion_r1329992452) this issue proposes a more accurate name for the `stopWithError` func

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/219