### PR TITLE
Include docu link and repo url in module-config template

### DIFF
--- a/module-config-template.yaml
+++ b/module-config-template.yaml
@@ -4,3 +4,6 @@ version: {{.Version}}
 defaultCR: config/samples/default_serverless_cr.yaml
 manifest: serverless-operator.yaml
 security: sec-scanners-config.yaml
+annotations:
+  "operator.kyma-project.io/doc-url": "https://kyma-project.io/#/serverless-manager/user/README"
+moduleRepo: https://github.com/kyma-project/serverless-manager.git


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

 - include doc url and github repo url

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/254