### PR TITLE
remove makefile target run-without-lifecycle-manager-operator

### DIFF
--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -117,11 +117,6 @@ run-with-lifecycle-manager:
 run-without-lifecycle-manager:
 	@make -C ${PROJECT_COMMON} run-without-lifecycle-manager
 
-#TODO: remove it after change run-without-lifecycle-manager-operator->run-without-lifecycle-manager in test-infra
-.PHONY: run-without-lifecycle-manager-operator
-run-without-lifecycle-manager-operator:
-	@make -C ${PROJECT_COMMON} run-without-lifecycle-manager
-
 .PHONY: run-without-lm-on-cluster
 run-without-lm-on-cluster:
 	@make -C ${PROJECT_COMMON} run-without-lm-on-cluster


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove makefile target run-without-lifecycle-manager-operator - unused after changes in test-infra (https://github.com/kyma-project/test-infra/pull/9050)

**Related issue(s)**
See also https://github.com/kyma-project/test-infra/issues/8991