### PR TITLE
Bump serverless images before v1.1.0 release

### DIFF
--- a/config/serverless/values.yaml
+++ b/config/serverless/values.yaml
@@ -82,32 +82,32 @@ global:
       directory: "prod"
     function_controller:
       name: "function-controller"
-      version: "PR-348"
-      directory: "dev"
+      version: "v20231012-d3306d5d"
+      directory: "prod"
     function_webhook:
       name: "function-webhook"
-      version: "PR-348"
-      directory: "dev"
+      version: "v20231012-d3306d5d"
+      directory: "prod"
     function_build_init:
       name: "function-build-init"
-      version: "PR-348"
-      directory: "dev"
+      version: "v20231012-d3306d5d"
+      directory: "prod"
     function_registry_gc:
       name: "function-registry-gc"
-      version: "PR-348"
-      directory: "dev"
+      version: "v20231012-d3306d5d"
+      directory: "prod"
     function_runtime_nodejs16:
       name: "function-runtime-nodejs16"
-      version: "PR-347"
-      directory: "dev"
+      version: "v20231010-c44aa328"
+      directory: "prod"
     function_runtime_nodejs18:
       name: "function-runtime-nodejs18"
-      version: "PR-347"
-      directory: "dev"
+      version: "v20231010-c44aa328"
+      directory: "prod"
     function_runtime_python39:
       name: "function-runtime-python39"
-      version: "PR-347"
-      directory: "dev"
+      version: "v20231010-c44aa328"
+      directory: "prod"
     kaniko_executor:
       name: "tpi/kaniko-executor"
       version: "1.9.1-406380b9"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,13 +2,13 @@ module-name: serverless
 rc-tag: v1.0.3
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/serverless-operator:1.1.0
-  - europe-docker.pkg.dev/kyma-project/prod/function-controller:v20231004-8de88f82
-  - europe-docker.pkg.dev/kyma-project/prod/function-build-init:v20231004-8de88f82
-  - europe-docker.pkg.dev/kyma-project/prod/function-webhook:v20231004-8de88f82
+  - europe-docker.pkg.dev/kyma-project/prod/function-controller:v20231012-d3306d5d
+  - europe-docker.pkg.dev/kyma-project/prod/function-build-init:v20231012-d3306d5d
+  - europe-docker.pkg.dev/kyma-project/prod/function-webhook:v20231012-d3306d5d
   - europe-docker.pkg.dev/kyma-project/prod/tpi/registry:2.8.1-1b099a1d
-  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs16:v20230831-fb331fc0
-  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs18:v20230831-fb331fc0
-  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-python39:v20230906-8690735f
+  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs16:v20231010-c44aa328
+  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-nodejs18:v20231010-c44aa328
+  - europe-docker.pkg.dev/kyma-project/prod/function-runtime-python39:v20231010-c44aa328
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- update serverless images tags in charts and security config

