### PR TITLE
Temporary copy module-chart also to components/operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,16 +151,20 @@ configure-git-origin:
 
 ##@ Build Dependencies
 MODULECHART=module-chart
+MODULECHARTOPERATOR=components/operator/module-chart
 
 .PHONY: module-chart
 module-chart: ## Copy serverless chart from config/serverless to module-chart
 module-chart: module-chart-clean
 	mkdir -p ${MODULECHART}
 	cp -r config/serverless/* ${MODULECHART}
+	mkdir -p ${MODULECHARTOPERATOR}
+	cp -r config/serverless/* ${MODULECHARTOPERATOR}
 
 .PHONY: module-chart-clean
 module-chart-clean: ## Remove the module-chart dir.
 	rm -rf ${MODULECHART}
+	rm -rf ${MODULECHARTOPERATOR}
 
 ##@ Tools
 


### PR DESCRIPTION
**Description**
Due to moving `Dockerfile` to `components/operator` in the next PR we need to have `module-chart` in the same dir as the `Dockerfile`. Coping `module-chart` to the "root" dir will be removed in the same PR as moving `Dockerfile` to `components/operator`.

Changes proposed in this pull request:

- Temporary copy module-chart also to components/operator

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/345
