### PR TITLE
Remove module chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !components/operator/internal
 !go.sum
 !go.mod
+!config/serverless

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,5 @@
 !components/operator/api
 !components/operator/controllers
 !components/operator/internal
-!module-chart
 !go.sum
 !go.mod

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
 COPY --chown=65532:65532 --from=builder /workspace/operator .
-COPY --chown=65532:65532 --from=builder /workspace/module-chart ./module-chart
 USER 65532:65532
 
 ENTRYPOINT ["/operator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /workspace
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod go.sum go.sum ./
-
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -22,6 +21,7 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
 COPY --chown=65532:65532 --from=builder /workspace/operator .
+COPY --chown=65532:65532 config/serverless /module-chart
 USER 65532:65532
 
 ENTRYPOINT ["/operator"]

--- a/Makefile
+++ b/Makefile
@@ -75,21 +75,21 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest module-chart ## Run unit tests.
+test: manifests generate fmt vet envtest  ## Run unit tests.
 	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=2m KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet module-chart ## Build operator binary.
-	go build -o bin/operator main.go
+build: generate fmt vet ## Build operator binary.
+	go build -o bin/operator components/operator/main.go
 
 .PHONY: run
-run: manifests generate fmt vet module-chart ## Run a controller from your host.
+run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: manifests generate module-chart ## Build docker image with the operator.
+docker-build: manifests generate ## Build docker image with the operator.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push
@@ -148,23 +148,6 @@ configure-git-origin:
 #	the CLI is looking for the origin url in the .git dir so first we need to be sure it's not empty
 	@git remote | grep '^origin$$' -q || \
 		git remote add origin https://github.com/kyma-project/serverless-manager
-
-##@ Build Dependencies
-MODULECHART=module-chart
-MODULECHARTOPERATOR=components/operator/module-chart
-
-.PHONY: module-chart
-module-chart: ## Copy serverless chart from config/serverless to module-chart
-module-chart: module-chart-clean
-	mkdir -p ${MODULECHART}
-	cp -r config/serverless/* ${MODULECHART}
-	mkdir -p ${MODULECHARTOPERATOR}
-	cp -r config/serverless/* ${MODULECHARTOPERATOR}
-
-.PHONY: module-chart-clean
-module-chart-clean: ## Remove the module-chart dir.
-	rm -rf ${MODULECHART}
-	rm -rf ${MODULECHARTOPERATOR}
 
 ##@ Tools
 

--- a/components/operator/controllers/suite_test.go
+++ b/components/operator/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -91,7 +90,7 @@ var _ = BeforeSuite(func() {
 	reconcilerLogger, err := config.Build()
 	Expect(err).NotTo(HaveOccurred())
 
-	chartPath := filepath.Join("..", "..", "..", "module-chart")
+	chartPath := filepath.Join("..", "..", "..", "config", "serverless")
 	err = (NewServerlessReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetConfig(),
@@ -117,9 +116,5 @@ var _ = AfterSuite(func() {
 
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-
-	By("removing orphant cache file")
-	err = os.RemoveAll(filepath.Join("..", "module-chart", "manifest"))
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/components/operator/internal/config/config.go
+++ b/components/operator/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import "github.com/vrischmann/envconfig"
 
 type Config struct {
-	ChartPath                  string `envconfig:"default=/module-chart"`
+	ChartPath                  string `envconfig:"default=/config/serverless"`
 	ServerlessManagerNamespace string `envconfig:"default=default"`
 }
 

--- a/components/operator/internal/config/config.go
+++ b/components/operator/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import "github.com/vrischmann/envconfig"
 
 type Config struct {
-	ChartPath                  string `envconfig:"default=/config/serverless"`
+	ChartPath                  string `envconfig:"default=/module-chart"`
 	ServerlessManagerNamespace string `envconfig:"default=default"`
 }
 


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Remove `module-chart`
- Use `config/serverless` instead of `module-chart`

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/345